### PR TITLE
Adding uhuruphotos to mvi list

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,11 @@
 
     - Tech Stack = Koin, Coroutines, Room, workflow, LiveData, ViewModel, Compose
 
+- https://github.com/savvasdalkitsis/uhuruphotos-android/
+
+    - 🖼️ [UhuruPhotos](https://github.com/savvasdalkitsis/uhuruphotos-android/) is an Android client for [LibrePhotos](https://github.com/LibrePhotos/librephotos/) written using the latest Android technologies, like Jetpack Compose, SQLDelight, Coroutines etc using an MVI architecture.
+
+    - It borrows a lot of ideas from Google Photos and aims to become a full featured photo album replacement, including features like offline support, backup and sync etc.
 
 ### Other
 


### PR DESCRIPTION
# <img src="https://github.com/savvasdalkitsis/uhuruphotos-android/raw/main/icons/src/main/ic_launcher-playstore.png" alt="logo" width = 60px> UhuruPhotos. A LibrePhotos client

UhuruPhotos is an Android client for [LibrePhotos](https://github.com/LibrePhotos/librephotos) 
written using the latest Android technologies, like Jetpack Compose, SQLDelight, Coroutines etc 
using an MVI architecture.

It borrows a lot of ideas from Google Photos and aims to become a full featured photo album 
replacement, including features like offline support, backup and sync etc.